### PR TITLE
Fix build

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -321,7 +321,8 @@ public class TextInputChannel {
   public void commitContent(int inputClientId, Map<String, Object> content) {
     Log.v(TAG, "Sending 'commitContent' message.");
     channel.invokeMethod(
-        "TextInputClient.performAction", Arrays.asList(inputClientId, "TextInputAction.commitContent", content));
+        "TextInputClient.performAction",
+        Arrays.asList(inputClientId, "TextInputAction.commitContent", content));
   }
 
   /** Instructs Flutter to execute an "unspecified" action. */

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -4,15 +4,10 @@
 
 package io.flutter.plugin.editing;
 
-import java.io.FileNotFoundException;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.util.Map;
-import java.util.HashMap;
-
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.DynamicLayout;
@@ -28,17 +23,19 @@ import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
-import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputContentInfo;
-import android.net.Uri;
-
-import androidx.core.view.inputmethod.InputConnectionCompat;
+import android.view.inputmethod.InputMethodManager;
 import androidx.core.os.BuildCompat;
-
+import androidx.core.view.inputmethod.InputConnectionCompat;
 import io.flutter.Log;
 import io.flutter.embedding.android.KeyboardManager;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 class InputConnectionAdaptor extends BaseInputConnection
     implements ListenableEditingState.EditingStateWatcher {
@@ -488,7 +485,8 @@ class InputConnectionAdaptor extends BaseInputConnection
   @Override
   public boolean commitContent(InputContentInfo inputContentInfo, int flags, Bundle opts) {
     // Ensure permission is granted
-    if (BuildCompat.isAtLeastNMR1() && (flags & InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION) != 0) {
+    if (BuildCompat.isAtLeastNMR1()
+        && (flags & InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION) != 0) {
       try {
         inputContentInfo.requestPermission();
       } catch (Exception e) {
@@ -537,7 +535,8 @@ class InputConnectionAdaptor extends BaseInputConnection
         baos.write(buffer, 0, len);
       }
       return baos.toByteArray();
-    } catch (Exception e) {}
+    } catch (Exception e) {
+    }
 
     return new byte[0];
   }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -340,15 +340,16 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     }
     outAttrs.imeOptions |= enterAction;
 
-    String[] imgTypeString = new String[] {
-      "image/png",
-      "image/bmp",
-      "image/jpg",
-      "image/tiff",
-      "image/gif",
-      "image/jpeg",
-      "image/webp"
-    };
+    String[] imgTypeString =
+        new String[] {
+          "image/png",
+          "image/bmp",
+          "image/jpg",
+          "image/tiff",
+          "image/gif",
+          "image/jpeg",
+          "image/webp"
+        };
     EditorInfoCompat.setContentMimeTypes(outAttrs, imgTypeString);
 
     InputConnectionAdaptor connection =

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -208,7 +208,7 @@ public class InputConnectionAdaptorTest {
             .send(
                     channelCaptor.capture(),
                     bufferCaptor.capture(),
-                    any(BinaryMessenger.BinaryReply.class));
+                    isNull());
     assertEquals("flutter/textinput", channelCaptor.getValue());
     verifyMethodCall(
             bufferCaptor.getValue(),

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -16,12 +16,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import android.view.inputmethod.InputContentInfo;
-import android.net.Uri;
 import android.content.ClipDescription;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.InputType;
@@ -34,6 +33,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.ExtractedText;
 import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputContentInfo;
 import android.view.inputmethod.InputMethodManager;
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
@@ -185,40 +185,33 @@ public class InputConnectionAdaptorTest {
     TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
     ListenableEditingState editable = sampleEditable(0, 0);
     InputConnectionAdaptor adaptor =
-            new InputConnectionAdaptor(
-                    testView,
-                    client,
-                    textInputChannel,
-                    mockKeyboardManager,
-                    editable,
-                    null,
-                    mockFlutterJNI);
+        new InputConnectionAdaptor(
+            testView,
+            client,
+            textInputChannel,
+            mockKeyboardManager,
+            editable,
+            null,
+            mockFlutterJNI);
     adaptor.commitContent(
-            new InputContentInfo(
-                    Uri.parse("content://mock/uri/test/commitContent"),
-                    new ClipDescription("commitContent test", new String[] { "image/png" })
-            ),
-            0,
-            null
-    );
+        new InputContentInfo(
+            Uri.parse("content://mock/uri/test/commitContent"),
+            new ClipDescription("commitContent test", new String[] {"image/png"})),
+        0,
+        null);
 
     ArgumentCaptor<String> channelCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
-    verify(dartExecutor, times(1))
-            .send(
-                    channelCaptor.capture(),
-                    bufferCaptor.capture(),
-                    isNull());
+    verify(dartExecutor, times(1)).send(channelCaptor.capture(), bufferCaptor.capture(), isNull());
     assertEquals("flutter/textinput", channelCaptor.getValue());
     verifyMethodCall(
-            bufferCaptor.getValue(),
-            "TextInputClient.performAction",
-            new String[] {
-                    "0",
-                    "TextInputAction.commitContent",
-                    "{\"data\":[],\"mimeType\":\"image\\/png\",\"uri\":\"content:\\/\\/mock\\/uri\\/test\\/commitContent\"}"
-            }
-    );
+        bufferCaptor.getValue(),
+        "TextInputClient.performAction",
+        new String[] {
+          "0",
+          "TextInputAction.commitContent",
+          "{\"data\":[],\"mimeType\":\"image\\/png\",\"uri\":\"content:\\/\\/mock\\/uri\\/test\\/commitContent\"}"
+        });
   }
 
   @Test


### PR DESCRIPTION
This PR updates the formatting to match what is expected by ci/format.sh and removes reference to BinaryMessage from InputConnectionAdapterTest.java so that tests will compile


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
