### PR TITLE
fix incompatible types for TextInputChannel.Configuration

### DIFF
--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1357,7 +1357,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill,
-            new TextInputChannel.Configuration[] {config},
+            null,
             null));
 
     final ViewStructure viewStructure = mock(ViewStructure.class);
@@ -1520,7 +1520,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill1,
-            new TextInputChannel.Configuration[] {config1, config2},
+            null,
             null));
 
     final ViewStructure viewStructure = mock(ViewStructure.class);
@@ -1666,7 +1666,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill1,
-            new TextInputChannel.Configuration[] {config1, config2},
+            null,
             null);
 
     textInputPlugin.setTextInputClient(0, autofillConfiguration);
@@ -1799,7 +1799,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill1,
-            new TextInputChannel.Configuration[] {config1, config2},
+            null,
             null);
 
     textInputPlugin.setTextInputClient(0, autofillConfiguration);
@@ -1897,7 +1897,7 @@ public class TextInputPluginTest {
             null,
             null,
             autofill1,
-            new TextInputChannel.Configuration[] {config1, config2},
+            null,
             null);
 
     textInputPlugin.setTextInputClient(0, autofillConfiguration);


### PR DESCRIPTION
fix incompatible types for TextInputChannel.Configuration

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ x] I listed at least one issue that this PR fixes in the description above.
- [ x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I signed the [CLA].
- [x ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
